### PR TITLE
Notification dropdown fix

### DIFF
--- a/webapp/src/Controller/Team/ClarificationController.php
+++ b/webapp/src/Controller/Team/ClarificationController.php
@@ -130,6 +130,9 @@ class ClarificationController extends BaseController
 
         $data = [
             'clarification' => $clarification,
+            'unreadClarifications' => $user->getTeam()->getUnreadClarifications()->filter(
+                fn(Clarification $c) => $c->getContest()->getCid() === $this->dj->getCurrentContest($user->getTeam()->getTeamid())->getCid()
+            ),
             'team' => $team,
             'categories' => $categories,
             'form' => $form->createView(),

--- a/webapp/src/Controller/Team/ClarificationController.php
+++ b/webapp/src/Controller/Team/ClarificationController.php
@@ -131,7 +131,7 @@ class ClarificationController extends BaseController
         $data = [
             'clarification' => $clarification,
             'unreadClarifications' => $user->getTeam()->getUnreadClarifications()->filter(
-                fn(Clarification $c) => $c->getContest()->getCid() === $this->dj->getCurrentContest($user->getTeam()->getTeamid())->getCid()
+                fn(Clarification $c) => $team->canViewClarification($c)
             ),
             'team' => $team,
             'categories' => $categories,

--- a/webapp/src/Controller/Team/ClarificationController.php
+++ b/webapp/src/Controller/Team/ClarificationController.php
@@ -131,7 +131,7 @@ class ClarificationController extends BaseController
         $data = [
             'clarification' => $clarification,
             'unreadClarifications' => $user->getTeam()->getUnreadClarifications()->filter(
-                fn(Clarification $c) => $team->canViewClarification($c)
+                fn(Clarification $c) => $c->getContest()->getCid() === $this->dj->getCurrentContest($user->getTeam()->getTeamid())->getCid()
             ),
             'team' => $team,
             'categories' => $categories,

--- a/webapp/src/Controller/Team/MiscController.php
+++ b/webapp/src/Controller/Team/MiscController.php
@@ -135,6 +135,9 @@ class MiscController extends BaseController
 
             $data['clarifications']        = $clarifications;
             $data['clarificationRequests'] = $clarificationRequests;
+            $data['unreadClarifications'] = $team->getUnreadClarifications()->filter(
+                fn(Clarification $c) => $c->getContest()->getCid() === $contest->getCid()
+            );
             $data['categories']            = $this->config->get('clar_categories');
             $data['allowDownload']         = (bool)$this->config->get('allow_team_submission_download');
         }

--- a/webapp/src/Controller/Team/ProblemController.php
+++ b/webapp/src/Controller/Team/ProblemController.php
@@ -57,7 +57,7 @@ class ProblemController extends BaseController
 
         $data = $this->dj->getTwigDataForProblemsAction($team->getTeamid(), $this->stats);
         $data['unreadClarifications'] = $team->getUnreadClarifications()->filter(
-            fn(Clarification $c) => $team->canViewClarification($c)
+            fn(Clarification $c) => $c->getContest()->getCid() === $this->dj->getCurrentContest($team->getTeamid())->getCid()
         );
 
         return $this->render('team/problems.html.twig', $data);

--- a/webapp/src/Controller/Team/ProblemController.php
+++ b/webapp/src/Controller/Team/ProblemController.php
@@ -3,6 +3,7 @@
 namespace App\Controller\Team;
 
 use App\Controller\BaseController;
+use App\Entity\Clarification;
 use App\Entity\Contest;
 use App\Entity\ContestProblem;
 use App\Service\ConfigurationService;
@@ -55,7 +56,9 @@ class ProblemController extends BaseController
         $team = $this->dj->getUser()->getTeam();
 
         $data = $this->dj->getTwigDataForProblemsAction($team->getTeamid(), $this->stats);
-        $data['team'] = $team;
+        $data['unreadClarifications'] = $team->getUnreadClarifications()->filter(
+            fn(Clarification $c) => $c->getContest()->getCid() === $this->dj->getCurrentContest($team->getTeamid())->getCid()
+        );
 
         return $this->render('team/problems.html.twig', $data);
     }

--- a/webapp/src/Controller/Team/ProblemController.php
+++ b/webapp/src/Controller/Team/ProblemController.php
@@ -57,7 +57,7 @@ class ProblemController extends BaseController
 
         $data = $this->dj->getTwigDataForProblemsAction($team->getTeamid(), $this->stats);
         $data['unreadClarifications'] = $team->getUnreadClarifications()->filter(
-            fn(Clarification $c) => $c->getContest()->getCid() === $this->dj->getCurrentContest($team->getTeamid())->getCid()
+            fn(Clarification $c) => $team->canViewClarification($c)
         );
 
         return $this->render('team/problems.html.twig', $data);

--- a/webapp/src/Controller/Team/ScoreboardController.php
+++ b/webapp/src/Controller/Team/ScoreboardController.php
@@ -3,6 +3,7 @@
 namespace App\Controller\Team;
 
 use App\Controller\BaseController;
+use App\Entity\Clarification;
 use App\Entity\Team;
 use App\Service\ConfigurationService;
 use App\Service\DOMJudgeService;
@@ -55,7 +56,10 @@ class ScoreboardController extends BaseController
             $request, $response, $refreshUrl, false, false, false, $contest
         );
         $data['myTeamId'] = $user->getTeam()->getTeamid();
-        $data['team'] = $user->getTeam();
+
+        $data['unreadClarifications'] = $user->getTeam()->getUnreadClarifications()->filter(
+            fn(Clarification $c) => $c->getContest()->getCid() === $this->dj->getCurrentContest($user->getTeam()->getTeamid())->getCid()
+        );
 
         if ($request->isXmlHttpRequest()) {
             $data['current_contest'] = $contest;

--- a/webapp/src/Controller/Team/ScoreboardController.php
+++ b/webapp/src/Controller/Team/ScoreboardController.php
@@ -58,7 +58,7 @@ class ScoreboardController extends BaseController
         $data['myTeamId'] = $user->getTeam()->getTeamid();
 
         $data['unreadClarifications'] = $user->getTeam()->getUnreadClarifications()->filter(
-            fn(Clarification $c) => $c->getContest()->getCid() === $this->dj->getCurrentContest($user->getTeam()->getTeamid())->getCid()
+            fn(Clarification $c) => $user->getTeam()->canViewClarification($c)
         );
 
         if ($request->isXmlHttpRequest()) {

--- a/webapp/src/Controller/Team/ScoreboardController.php
+++ b/webapp/src/Controller/Team/ScoreboardController.php
@@ -58,7 +58,7 @@ class ScoreboardController extends BaseController
         $data['myTeamId'] = $user->getTeam()->getTeamid();
 
         $data['unreadClarifications'] = $user->getTeam()->getUnreadClarifications()->filter(
-            fn(Clarification $c) => $user->getTeam()->canViewClarification($c)
+            fn(Clarification $c) => $c->getContest()->getCid() === $this->dj->getCurrentContest($user->getTeam()->getTeamid())->getCid()
         );
 
         if ($request->isXmlHttpRequest()) {

--- a/webapp/templates/team/menu.html.twig
+++ b/webapp/templates/team/menu.html.twig
@@ -46,17 +46,21 @@
             {% include 'partials/menu_help_button.html.twig' %}
         </div>
 
-        {% if team is defined and team.unreadClarifications|length > 0 %}
+        {% if unreadClarifications is defined and unreadClarifications|length > 0 %}
             <div class="dropdown mb-2 mb-xl-0 mr-3">
-                <button class="btn btn-warning btn-sm dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="false">
+                <button class="btn btn-warning btn-sm dropdown-toggle" type="button" data-toggle="dropdown"
+                        aria-expanded="false">
                     Unread messages
-                    <span class="badge badge-secondary">{{ team.unreadClarifications|length }}</span>
+                    <span class="badge badge-secondary">{{ unreadClarifications|length }}</span>
                 </button>
                 <div class="dropdown-menu overflow-auto" style="max-height: 30rem">
-                    {% for clarification in team.unreadClarifications %}
+                    {% for clarification in unreadClarifications %}
                         <div style="width: 18rem">
-                            <a class="dropdown-item py-2" href="{{ path('team_clarification', {clarId: clarification.clarid}) }}">
-                                <p class="mb-1 text-right"><span class="text-muted">{{ clarification.submittime|round|date('d. m. H:i')  }}</span></p>
+                            <a class="dropdown-item py-2"
+                               href="{{ path('team_clarification', {clarId: clarification.clarid}) }}">
+                                <p class="mb-1 text-right"><span
+                                        class="text-muted">{{ clarification.submittime|round|date('d. m. H:i') }}</span>
+                                </p>
                                 <p class="card-text text-wrap">{{ clarification.summary }}</p>
                             </a>
                             <hr class="m-0">
@@ -68,7 +72,8 @@
 
         <div id="submitbut">
             {% if is_granted('ROLE_JURY') or (current_team_contest is not null and current_team_contest.freezeData.started) %}
-                <a class="justify-content-center" data-ajax-modal data-ajax-modal-after="initSubmitModal" href="{{ path('team_submit') }}">
+                <a class="justify-content-center" data-ajax-modal data-ajax-modal-after="initSubmitModal"
+                   href="{{ path('team_submit') }}">
                     <span class="btn btn-success btn-sm mr-3 mb-2 mb-xl-0">
                         <i class="fas fa-cloud-upload-alt"></i> Submit
                     </span>


### PR DESCRIPTION
reprodukoval jsem problem na lokalu. spocival v tom, ze `team.unreadClarifications` obsahuje **vsechny** clarifications, ktere tym nevidel. nehlede na okolnosti - treba i kdyz k ni ani nema pristup. ted se do templatu predavaji jenom ty spojene s aktualne zvolenym contestem. otestoval jsem to, bug by mel byt eliminovan.

znamena to tedy, ze uzivatel vzdy uvidi jen clarifications ze zvoleneho contestu. je to zadouci? (mozna ano)

plus ted se dropdown zobrazi i na strance, kde si uzivatel prohlizi jednu zpravu, po tom co klikne na notifikaci (/team/clarification/{id} apod.)