### PR TITLE
Custom contest URL parameter

### DIFF
--- a/webapp/config/services.yaml
+++ b/webapp/config/services.yaml
@@ -9,6 +9,8 @@ parameters:
     # This code is rarely tested and we discourage using it.
     removed_intervals: false
     image_directory: '%kernel.project_dir%/public/media/images'
+    # The actions for which to add the CID to the URL.
+    contest_id_url_actions: ['scoreboardAction', 'problemsAction']
 
 services:
     # default configuration for services in *this* file
@@ -60,3 +62,7 @@ services:
         public: true
         arguments:
             $configCache: '@config_cache_factory'
+
+    App\EventSubscriber\ContestIdSubscriber:
+        arguments:
+            $contestIdUrlActions: '%contest_id_url_actions%'

--- a/webapp/src/Controller/Jury/JuryMiscController.php
+++ b/webapp/src/Controller/Jury/JuryMiscController.php
@@ -15,6 +15,7 @@ use App\Service\ScoreboardService;
 use App\Utils\Utils;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query\Expr\Join;
+use GuzzleHttp\Psr7\Uri;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -335,7 +336,8 @@ class JuryMiscController extends BaseController
     public function changeContestAction(Request $request, RouterInterface $router, int $contestId): Response
     {
         if ($this->isLocalReferer($router, $request)) {
-            $response = new RedirectResponse($request->headers->get('referer'));
+            $uri = new Uri($request->headers->get('referer'));
+            $response = new RedirectResponse((string)$uri->withQuery(''));
         } else {
             $response = $this->redirectToRoute('jury_index');
         }

--- a/webapp/src/Controller/PublicController.php
+++ b/webapp/src/Controller/PublicController.php
@@ -13,6 +13,7 @@ use App\Service\StatisticsService;
 use DateTime;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\NonUniqueResultException;
+use GuzzleHttp\Psr7\Uri;
 use ReflectionClass;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -236,7 +237,8 @@ class PublicController extends BaseController
     public function changeContestAction(Request $request, RouterInterface $router, int $contestId): Response
     {
         if ($this->isLocalReferer($router, $request)) {
-            $response = new RedirectResponse($request->headers->get('referer'));
+            $uri = new Uri($request->headers->get('referer'));
+            $response = new RedirectResponse((string)$uri->withQuery(''));
         } else {
             $response = $this->redirectToRoute('public_scoreboard');
         }

--- a/webapp/src/Controller/Team/MiscController.php
+++ b/webapp/src/Controller/Team/MiscController.php
@@ -74,8 +74,6 @@ class MiscController extends BaseController
         $teamId  = $team->getTeamid();
         $contest = $this->dj->getCurrentContest($teamId);
 
-        $this->checkForSendingWelcomeMessage($contest->getCid());
-
         $data = [
             'team' => $team,
             'contest' => $contest,
@@ -87,6 +85,8 @@ class MiscController extends BaseController
             'maxWidth' => $this->config->get('team_column_width'),
         ];
         if ($contest) {
+            $this->checkForSendingWelcomeMessage($contest->getCid());
+
             $scoreboard = $this->scoreboardService
                 ->getTeamScoreboard($contest, $teamId, false);
             $data = array_merge(
@@ -162,7 +162,9 @@ class MiscController extends BaseController
      */
     public function changeContestAction(Request $request, RouterInterface $router, int $contestId): Response
     {
-        $this->checkForSendingWelcomeMessage($contestId);
+        if ($contestId != -1) {
+            $this->checkForSendingWelcomeMessage($contestId);
+        }
 
         if ($this->isLocalReferer($router, $request)) {
             $response = new RedirectResponse($request->headers->get('referer'));

--- a/webapp/src/Controller/Team/MiscController.php
+++ b/webapp/src/Controller/Team/MiscController.php
@@ -15,6 +15,7 @@ use App\Utils\Utils;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\NoResultException;
+use GuzzleHttp\Psr7\Uri;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
@@ -167,7 +168,8 @@ class MiscController extends BaseController
         }
 
         if ($this->isLocalReferer($router, $request)) {
-            $response = new RedirectResponse($request->headers->get('referer'));
+            $uri = new Uri($request->headers->get('referer'));
+            $response = new RedirectResponse((string)$uri->withQuery(''));
         } else {
             $response = $this->redirectToRoute('team_index');
         }

--- a/webapp/src/Controller/Team/ProblemController.php
+++ b/webapp/src/Controller/Team/ProblemController.php
@@ -56,9 +56,11 @@ class ProblemController extends BaseController
         $team = $this->dj->getUser()->getTeam();
 
         $data = $this->dj->getTwigDataForProblemsAction($team->getTeamid(), $this->stats);
-        $data['unreadClarifications'] = $team->getUnreadClarifications()->filter(
-            fn(Clarification $c) => $c->getContest()->getCid() === $this->dj->getCurrentContest($team->getTeamid())->getCid()
-        );
+        if ($contest = $this->dj->getCurrentContest($team->getTeamid())) {
+            $data['unreadClarifications'] = $team->getUnreadClarifications()->filter(
+                fn(Clarification $c) => $c->getContest()->getCid() === $contest->getCid()
+            );
+        }
 
         return $this->render('team/problems.html.twig', $data);
     }

--- a/webapp/src/Controller/Team/ScoreboardController.php
+++ b/webapp/src/Controller/Team/ScoreboardController.php
@@ -57,9 +57,11 @@ class ScoreboardController extends BaseController
         );
         $data['myTeamId'] = $user->getTeam()->getTeamid();
 
-        $data['unreadClarifications'] = $user->getTeam()->getUnreadClarifications()->filter(
-            fn(Clarification $c) => $c->getContest()->getCid() === $this->dj->getCurrentContest($user->getTeam()->getTeamid())->getCid()
-        );
+        if ($contest = $this->dj->getCurrentContest($user->getTeam()->getTeamid())) {
+            $data['unreadClarifications'] = $user->getTeam()->getUnreadClarifications()->filter(
+                fn(Clarification $c) => $c->getContest()->getCid() === $contest->getCid()
+            );
+        }
 
         if ($request->isXmlHttpRequest()) {
             $data['current_contest'] = $contest;

--- a/webapp/src/EventSubscriber/ContestIdSubscriber.php
+++ b/webapp/src/EventSubscriber/ContestIdSubscriber.php
@@ -1,0 +1,86 @@
+<?php declare(strict_types=1);
+
+namespace App\EventSubscriber;
+
+use App\Controller\PublicController;
+use App\Service\ConfigurationService;
+use App\Service\DOMJudgeService;
+use GuzzleHttp\Psr7\Uri;
+use GuzzleHttp\Psr7\UriNormalizer;
+use Psr\Container\ContainerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\KernelEvents;
+use function GuzzleHttp\Psr7\str;
+
+class ContestIdSubscriber implements EventSubscriberInterface
+{
+    private DOMJudgeService $dj;
+    private array $contestIdUrlActions;
+
+    public function __construct(DOMJudgeService $dj, array $contestIdUrlActions)
+    {
+        $this->dj = $dj;
+        $this->contestIdUrlActions = $contestIdUrlActions;
+    }
+
+    public function onKernelController(ControllerEvent $event)
+    {
+        if (!is_array($event->getController())) {
+            return;
+        }
+
+        $controllerAction = $event->getController()[1];
+        if (!in_array($controllerAction, $this->contestIdUrlActions)) {
+            return;
+        }
+
+        $event->getRequest()->attributes->set('check_cid_query', true);
+    }
+
+    public function onKernelResponse(ResponseEvent $event)
+    {
+        if (!$event->getRequest()->attributes->get('check_cid_query')) {
+            return;
+        }
+
+        $cid = (int)$event->getRequest()->query->get('cid');
+        $currentContest = $this->dj->getCurrentContest();
+
+        if (!$cid) {
+            if (!$currentContest) {
+                return;
+            }
+
+            $uri = new Uri($event->getRequest()->getRequestUri());
+            $uri = UriNormalizer::normalize($uri->withQuery('cid=' . $currentContest->getCid()));
+
+            $event->setResponse(new RedirectResponse((string)$uri));
+            return;
+        }
+
+        if (!$currentContest || $cid != $currentContest->getCid()) {
+            if (!$this->dj->getContest($cid)) {
+                return;
+            }
+
+            $response = new RedirectResponse($event->getRequest()->getRequestUri());
+            $response->headers->setCookie(new Cookie('domjudge_cid', (string)$cid));
+
+            $event->setResponse($response);
+        }
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::CONTROLLER => 'onKernelController',
+            KernelEvents::RESPONSE => 'onKernelResponse',
+        ];
+    }
+}


### PR DESCRIPTION
na vybranych routach (scoreboard a problemset - 27356d690303026749567b27a62bd4510407ad45) se query parametr "cid",
- pokud je, nacita a prepina se jim contest, a
- pokud neni, doplni se podle zrovna vybraneho.

changeContestAction (switcher) bylo nutne modifikovat (c03343979891cd1425f437e048fc8a85702bfa37), aby na zpetnem presmerovani odstranila query a nedoslo znovu k prepnuti podle URL.