### PR TITLE
Query `cid` fix

### DIFF
--- a/webapp/src/EventSubscriber/ContestIdSubscriber.php
+++ b/webapp/src/EventSubscriber/ContestIdSubscriber.php
@@ -63,11 +63,11 @@ class ContestIdSubscriber implements EventSubscriberInterface
         $teamId = $this->dj->getUser() ? $this->dj->getUser()->getTeamId() : -1;
         $currentContest = $this->dj->getCurrentContest($teamId);
 
-        if (!$cid) {
-            if (!$currentContest) {
-                return;
-            }
+        if (!$currentContest) {
+            return;
+        }
 
+        if (!$cid) {
             $queryParameters['cid'] = $currentContest->getCid();
             $responseUri = $requestUri->withQuery(http_build_query($queryParameters));
 
@@ -76,7 +76,8 @@ class ContestIdSubscriber implements EventSubscriberInterface
         }
 
         if (!$this->dj->getContest($cid) ||
-            ($currentContest && $currentContest->getCid() != $request->cookies->get('domjudge_cid'))) {
+            $currentContest->getCid() != $request->cookies->get('domjudge_cid')) {
+
             $queryParameters['cid'] = $currentContest->getCid();
             $responseUri = $requestUri->withQuery(http_build_query($queryParameters));
 
@@ -88,7 +89,7 @@ class ContestIdSubscriber implements EventSubscriberInterface
             return;
         }
 
-        if (!$currentContest || $cid != $currentContest->getCid()) {
+        if ($cid != $currentContest->getCid()) {
             $response = new RedirectResponse($request->getRequestUri());
             $response->headers->setCookie(new Cookie('domjudge_cid', (string)$cid));
 

--- a/webapp/src/EventSubscriber/ContestIdSubscriber.php
+++ b/webapp/src/EventSubscriber/ContestIdSubscriber.php
@@ -57,10 +57,16 @@ class ContestIdSubscriber implements EventSubscriberInterface
                 return;
             }
 
-            $uri = new Uri($event->getRequest()->getRequestUri());
-            $uri = UriNormalizer::normalize($uri->withQuery('cid=' . $currentContest->getCid()));
+            $requestUri = new Uri($event->getRequest()->getRequestUri());
 
-            $event->setResponse(new RedirectResponse((string)$uri));
+            $queryParameters = ['cid' => $currentContest->getCid()];
+            if (!empty($requestUri->getQuery())) {
+                parse_str($requestUri->getQuery(), $existingQueryParameters);
+                $queryParameters = array_merge($existingQueryParameters, $queryParameters);
+            }
+            $responseUri = $requestUri->withQuery(http_build_query($queryParameters));
+
+            $event->setResponse(new RedirectResponse((string)$responseUri));
             return;
         }
 


### PR DESCRIPTION
- query parametry se pri zapsani cid parametru zachovaji
- pri nevalidnim ci nepristupnem cid se
  - zobrazi naposledy zvoleny contest
  - cid parametr se prepise na zvoleny cid
- osetrena situace, kdy uzivatel nema pristup k zadnemu contestu