### PR TITLE
Oprava nadpisu v blog prispevcich

### DIFF
--- a/webapp/public/style_domjudge.css
+++ b/webapp/public/style_domjudge.css
@@ -392,7 +392,7 @@ tr.ignore td, td.ignore, span.ignore {
     border: 1px solid black;
 }
 
-.problem-list h2,h3,h4 {
+.problem-list h2, .problem-list h3, .problem-list h4 {
     text-align: center;
 }
 


### PR DESCRIPTION
DJ CSS ma v sobe nespravny selektor na nadpisy - ma se aplikovat jen v problemsetu, ale je i napr. v blogu.

predtim (viditelne i v [tomhle prispevku](https://pardubicky-hacker.delta-skola.cz/public/blog/webinar-predstaveni-platformy-pardubicky-hacker-programovani-pro-zs)):

![Screenshot from 2023-08-31 20-37-05](https://github.com/delta-cs/seminar-domjudge/assets/66163112/84354c45-c97e-464d-ab21-7aca78f299e4)

nyni:
![image](https://github.com/delta-cs/seminar-domjudge/assets/66163112/1889d261-f905-4ed6-bcdf-a0bb8e4c2468)
