### PR TITLE
Make the cgroups Docker volume not readonly

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     image: domjudge/domjudge-contributor
     hostname: domjudge-contributor
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup
       - .:/domjudge:cached
       - /chroot
     links:


### PR DESCRIPTION
same as [this upstream PR](https://github.com/DOMjudge/domjudge/pull/2317).

for [this reason](https://github.com/DOMjudge/domjudge-packaging/issues/170).